### PR TITLE
[BUGFIX] Could not find templates directory

### DIFF
--- a/src/View/ServiceProvider.php
+++ b/src/View/ServiceProvider.php
@@ -32,7 +32,7 @@ class ServiceProvider implements ServiceProviderInterface {
 		] );
 
 		$container[ WPEMERGETWIG_VIEW_TWIG_VIEW_ENGINE_KEY ] = function( $c ) {
-			$root = MixedType::normalizePath( ABSPATH );
+			$root = MixedType::normalizePath( WP_CONTENT_DIR . DIRECTORY_SEPARATOR );
 
 			$config = $c[ WPEMERGE_CONFIG_KEY ]['twig'];
 			$views = MixedType::toArray( $config['views'] );


### PR DESCRIPTION
If you don’t use the standard file organisation of wordpress Twig fails to find the templates.

The root should be compared with the WP_CONTENT_DIR constant and not ABS_PATH.

By default WP_CONTENT_DIR is `ABS_PATH . ‘wp-content’` in wp-includes/default-constants.php